### PR TITLE
Sort css entries for consistent output in perl 5.18+

### DIFF
--- a/lib/HTML/FromANSI/Tiny.pm
+++ b/lib/HTML/FromANSI/Tiny.pm
@@ -116,7 +116,7 @@ sub css {
 
   my @css = (
     map { "${prefix}$_ { " . $self->_css_attr_string($styles->{$_}) . " }" }
-      keys %$styles
+      sort keys %$styles
   );
 
   return wantarray ? @css : join('', @css);


### PR DESCRIPTION
This is a somewhat trivial patch which contains no actual functional changes, but does mean that the css emitted is consistent from run to run in perl 5.18+.

The new hash key randomization in perl 5.18 makes the following one-liner output something different each run:

`perl -MHTML::FromANSI::Tiny -E 'say HTML::FromANSI::Tiny->new->css'`

I use HTML::FromANSI::Tiny in Template::Plugin::DataPrinter, and one of my tests does a diff on HTML outputs created by different runs of HTML::FromANSI::Tiny. This test has [started failing with 5.18](http://www.cpantesters.org/cpan/report/fa7715e0-fc2f-11e2-862e-5f588eff5341), and this patch fixes it.

I'd be much obliged if you'd consider this patch, or something like it.
