### PR TITLE
Exclude escape sequences about cursor and screen from text

### DIFF
--- a/t/html.t
+++ b/t/html.t
@@ -49,4 +49,24 @@ eq_or_diff
   q[hey <span class="t_on_white t_black">LOOK AT THIS</span>],
   'with auto_reverse get default colors';
 
+eq_or_diff
+  scalar $h->html("\e[2j\e[2Jfoo"),
+  q[foo],
+  'with escape sequence to clear screen';
+
+eq_or_diff
+  scalar $h->html("\e[0k\e[0K\e[1k\e[1K\e[2k\e[2Kfoo"),
+  q[foo],
+  'with escape sequence to clear row';
+
+eq_or_diff
+  scalar $h->html("\e[1;2h\e[10;20Hfoo"),
+  q[foo],
+  'with escape sequence to move cursor by lengthwise and crosswise';
+
+eq_or_diff
+  scalar $h->html("\e[10a\e[10A\e[10b\e[10B\e[10c\e[10C\e[10d\e[10Dfoo"),
+  q[foo],
+  'with escape sequence to move cursor';
+
 done_testing;


### PR DESCRIPTION
Hello.

If we give text to `html()` like so;

``` perl
my $w = HTML::FromANSI::Tiny->new(auto_reverse => 1, background => 'white', foreground => 'black');
$w->html("^[[1A^[[2KPhantomJS 1.9.7 (Linux): Executed 5 of 10^[[32m SUCCESS^[[39m (0 secs / 0.066 secs)^[[0m"),
```

then, we'll get...
![http://gyazo.com/ccd1c0f9b4cc309c417aadd04f0787fe.png](http://gyazo.com/ccd1c0f9b4cc309c417aadd04f0787fe.png)

In this case, `[1A` and `[2K` are escape sequences to control screen and cursor. I feel such as these are noisy.

So I wrote a patch to exclude them.

How do you think?
Is execute such processing at this module right?  Or we should give pre-processed text to method?
